### PR TITLE
Show last 20 logins on user list for super admins

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
 
   # GET /users or /users.json
   def index
-    @users_by_role = User.order(:last_name, :first_name).group_by(&:role)
-    @recent_logins = User.where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(20) if current_user.super_admin?
+    @users_by_role = User.grouped_by_role
+    @recent_logins = User.recent_logins if current_user.super_admin?
   end
 
   # GET /users/1 or /users/1.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
   # GET /users or /users.json
   def index
     @users_by_role = User.order(:last_name, :first_name).group_by(&:role)
+    @recent_logins = User.where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(20) if current_user.super_admin?
   end
 
   # GET /users/1 or /users/1.json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
   scope :vocals, -> { where(role: :vocal) }
   scope :priests, -> { where(role: :priest) }
   scope :priests_without_setup, -> { priests.where.not(id: PriestSetup.select(:priest_id)) }
+  scope :grouped_by_role, -> { order(:last_name, :first_name).group_by(&:role) }
+  scope :recent_logins, -> { where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(20) }
 
   belongs_to :church, optional: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :invitable, :database_authenticatable,
-         :recoverable, :rememberable, :validatable, :lockable
+         :recoverable, :rememberable, :validatable, :lockable, :trackable
 
   has_one_attached :avatar, service: :amazon_avatar
 

--- a/app/views/users/_recent_logins.html.erb
+++ b/app/views/users/_recent_logins.html.erb
@@ -1,0 +1,41 @@
+<details class="mb-4 group border border-gray-200 border-l-4 border-l-blue-500 rounded-xl bg-white shadow-sm">
+  <summary class="flex items-center justify-between px-5 py-4 cursor-pointer select-none list-none">
+    <div class="flex items-center gap-2">
+      <i class="ph ph-clock-clockwise text-blue-500 text-lg"></i>
+      <h2 class="text-base font-semibold text-gray-700"><%= t("users.index.recent_logins") %></h2>
+      <span class="text-xs text-gray-400 font-medium">(<%= recent_logins.count %>)</span>
+    </div>
+    <i class="ph ph-caret-down text-gray-400 text-lg transition-transform duration-200 group-open:rotate-180"></i>
+  </summary>
+
+  <div class="px-5 pb-5">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <% recent_logins.each do |user| %>
+        <div class="bg-white border border-gray-200 border-t-4 border-t-blue-500 rounded-xl p-5 flex flex-col gap-4 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-0.5">
+          <div class="flex items-center gap-3">
+            <% if user.avatar.attached? %>
+              <%= image_tag url_for(user.avatar), class: "w-11 h-11 rounded-full object-cover shrink-0" %>
+            <% else %>
+              <div class="flex items-center justify-center w-11 h-11 rounded-full text-base font-bold shrink-0 bg-blue-100 text-blue-700">
+                <%= user.initials %>
+              </div>
+            <% end %>
+            <div class="min-w-0">
+              <p class="font-semibold text-gray-900 leading-tight truncate"><%= user.full_name %></p>
+              <p class="text-xs text-gray-400 truncate mt-0.5"><%= user.email %></p>
+              <p class="text-xs text-gray-500 mt-1">
+                <i class="ph ph-clock"></i> <%= user.last_sign_in_at.strftime("%d/%m/%Y %H:%M") %>
+              </p>
+            </div>
+          </div>
+
+          <div class="flex items-center justify-end mt-auto pt-3 border-t border-gray-100">
+            <%= link_to user, class: "flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-800" do %>
+              <i class="ph ph-arrow-right"></i> <%= t("users.index.show") %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</details>

--- a/app/views/users/_role_group.html.erb
+++ b/app/views/users/_role_group.html.erb
@@ -1,0 +1,58 @@
+<%
+  accent_class = case role
+    when "guardian" then "border-l-green-500"
+    when "vocal"    then "border-l-red-500"
+    when "priest"   then "border-l-purple-500"
+  end
+  avatar_class = case role
+    when "guardian" then "bg-green-100 text-green-700"
+    when "vocal"    then "bg-red-100 text-red-700"
+    when "priest"   then "bg-purple-100 text-purple-700"
+  end
+  accent_top_class = case role
+    when "guardian" then "border-t-green-500"
+    when "vocal"    then "border-t-red-500"
+    when "priest"   then "border-t-purple-500"
+  end
+%>
+
+<details class="mb-4 group border border-gray-200 border-l-4 <%= accent_class %> rounded-xl bg-white shadow-sm">
+  <summary class="flex items-center justify-between px-5 py-4 cursor-pointer select-none list-none">
+    <div class="flex items-center gap-2">
+      <h2 class="text-base font-semibold text-gray-700"><%= t("activerecord.attributes.user.roles_plural.#{role}") %></h2>
+      <span class="text-xs text-gray-400 font-medium">(<%= users.count %>)</span>
+    </div>
+    <i class="ph ph-caret-down text-gray-400 text-lg transition-transform duration-200 group-open:rotate-180"></i>
+  </summary>
+
+  <div class="px-5 pb-5">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <% users.each do |user| %>
+        <div class="bg-white border border-gray-200 border-t-4 <%= accent_top_class %> rounded-xl p-5 flex flex-col gap-4 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-0.5">
+          <div class="flex items-center gap-3">
+            <% if user.avatar.attached? %>
+              <%= image_tag url_for(user.avatar), class: "w-11 h-11 rounded-full object-cover shrink-0" %>
+            <% else %>
+              <div class="flex items-center justify-center w-11 h-11 rounded-full text-base font-bold shrink-0 <%= avatar_class %>">
+                <%= user.initials %>
+              </div>
+            <% end %>
+            <div class="min-w-0">
+              <p class="font-semibold text-gray-900 leading-tight truncate"><%= user.full_name %></p>
+              <p class="text-xs text-gray-400 truncate mt-0.5"><%= user.email %></p>
+              <% if user.phone.present? %>
+                <p class="text-xs text-gray-400 truncate mt-0.5"><i class="ph ph-phone"></i> <%= user.phone %></p>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="flex items-center justify-end mt-auto pt-3 border-t border-gray-100">
+            <%= link_to user, class: "flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-800" do %>
+              <i class="ph ph-arrow-right"></i> <%= t("users.index.show") %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</details>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,6 +6,50 @@
         action_label: t(".new_user"),
         action_path: new_user_path %>
 
+  <% if current_user.super_admin? && @recent_logins.any? %>
+    <details class="mb-4 group border border-gray-200 border-l-4 border-l-blue-500 rounded-xl bg-white shadow-sm">
+      <summary class="flex items-center justify-between px-5 py-4 cursor-pointer select-none list-none">
+        <div class="flex items-center gap-2">
+          <i class="ph ph-clock-clockwise text-blue-500 text-lg"></i>
+          <h2 class="text-base font-semibold text-gray-700"><%= t(".recent_logins") %></h2>
+          <span class="text-xs text-gray-400 font-medium">(<%= @recent_logins.count %>)</span>
+        </div>
+        <i class="ph ph-caret-down text-gray-400 text-lg transition-transform duration-200 group-open:rotate-180"></i>
+      </summary>
+
+      <div class="px-5 pb-5">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          <% @recent_logins.each do |user| %>
+            <div class="bg-white border border-gray-200 border-t-4 border-t-blue-500 rounded-xl p-5 flex flex-col gap-4 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-0.5">
+              <div class="flex items-center gap-3">
+                <% if user.avatar.attached? %>
+                  <%= image_tag url_for(user.avatar), class: "w-11 h-11 rounded-full object-cover shrink-0" %>
+                <% else %>
+                  <div class="flex items-center justify-center w-11 h-11 rounded-full text-base font-bold shrink-0 bg-blue-100 text-blue-700">
+                    <%= user.initials %>
+                  </div>
+                <% end %>
+                <div class="min-w-0">
+                  <p class="font-semibold text-gray-900 leading-tight truncate"><%= user.full_name %></p>
+                  <p class="text-xs text-gray-400 truncate mt-0.5"><%= user.email %></p>
+                  <p class="text-xs text-gray-500 mt-1">
+                    <i class="ph ph-clock"></i> <%= user.last_sign_in_at.strftime("%d/%m/%Y %H:%M") %>
+                  </p>
+                </div>
+              </div>
+
+              <div class="flex items-center justify-end mt-auto pt-3 border-t border-gray-100">
+                <%= link_to user, class: "flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-800" do %>
+                  <i class="ph ph-arrow-right"></i> <%= t(".show") %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </details>
+  <% end %>
+
   <% %w[guardian vocal priest].each do |role| %>
     <% users = @users_by_role[role] %>
     <% next if users.blank? %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -7,110 +7,12 @@
         action_path: new_user_path %>
 
   <% if current_user.super_admin? && @recent_logins.any? %>
-    <details class="mb-4 group border border-gray-200 border-l-4 border-l-blue-500 rounded-xl bg-white shadow-sm">
-      <summary class="flex items-center justify-between px-5 py-4 cursor-pointer select-none list-none">
-        <div class="flex items-center gap-2">
-          <i class="ph ph-clock-clockwise text-blue-500 text-lg"></i>
-          <h2 class="text-base font-semibold text-gray-700"><%= t(".recent_logins") %></h2>
-          <span class="text-xs text-gray-400 font-medium">(<%= @recent_logins.count %>)</span>
-        </div>
-        <i class="ph ph-caret-down text-gray-400 text-lg transition-transform duration-200 group-open:rotate-180"></i>
-      </summary>
-
-      <div class="px-5 pb-5">
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          <% @recent_logins.each do |user| %>
-            <div class="bg-white border border-gray-200 border-t-4 border-t-blue-500 rounded-xl p-5 flex flex-col gap-4 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-0.5">
-              <div class="flex items-center gap-3">
-                <% if user.avatar.attached? %>
-                  <%= image_tag url_for(user.avatar), class: "w-11 h-11 rounded-full object-cover shrink-0" %>
-                <% else %>
-                  <div class="flex items-center justify-center w-11 h-11 rounded-full text-base font-bold shrink-0 bg-blue-100 text-blue-700">
-                    <%= user.initials %>
-                  </div>
-                <% end %>
-                <div class="min-w-0">
-                  <p class="font-semibold text-gray-900 leading-tight truncate"><%= user.full_name %></p>
-                  <p class="text-xs text-gray-400 truncate mt-0.5"><%= user.email %></p>
-                  <p class="text-xs text-gray-500 mt-1">
-                    <i class="ph ph-clock"></i> <%= user.last_sign_in_at.strftime("%d/%m/%Y %H:%M") %>
-                  </p>
-                </div>
-              </div>
-
-              <div class="flex items-center justify-end mt-auto pt-3 border-t border-gray-100">
-                <%= link_to user, class: "flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-800" do %>
-                  <i class="ph ph-arrow-right"></i> <%= t(".show") %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </details>
+    <%= render "recent_logins", recent_logins: @recent_logins %>
   <% end %>
 
   <% %w[guardian vocal priest].each do |role| %>
     <% users = @users_by_role[role] %>
     <% next if users.blank? %>
-
-    <%
-      accent_class = case role
-        when "guardian" then "border-l-green-500"
-        when "vocal"    then "border-l-red-500"
-        when "priest"   then "border-l-purple-500"
-      end
-      avatar_class = case role
-        when "guardian" then "bg-green-100 text-green-700"
-        when "vocal"    then "bg-red-100 text-red-700"
-        when "priest"   then "bg-purple-100 text-purple-700"
-      end
-      accent_top_class = case role
-        when "guardian" then "border-t-green-500"
-        when "vocal"    then "border-t-red-500"
-        when "priest"   then "border-t-purple-500"
-      end
-    %>
-
-    <details class="mb-4 group border border-gray-200 border-l-4 <%= accent_class %> rounded-xl bg-white shadow-sm">
-      <summary class="flex items-center justify-between px-5 py-4 cursor-pointer select-none list-none">
-        <div class="flex items-center gap-2">
-          <h2 class="text-base font-semibold text-gray-700"><%= t("activerecord.attributes.user.roles_plural.#{role}") %></h2>
-          <span class="text-xs text-gray-400 font-medium">(<%= users.count %>)</span>
-        </div>
-        <i class="ph ph-caret-down text-gray-400 text-lg transition-transform duration-200 group-open:rotate-180"></i>
-      </summary>
-
-      <div class="px-5 pb-5">
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          <% users.each do |user| %>
-            <div class="bg-white border border-gray-200 border-t-4 <%= accent_top_class %> rounded-xl p-5 flex flex-col gap-4 shadow-sm hover:shadow-lg transition-all duration-200 hover:-translate-y-0.5">
-              <div class="flex items-center gap-3">
-                <% if user.avatar.attached? %>
-                  <%= image_tag url_for(user.avatar), class: "w-11 h-11 rounded-full object-cover shrink-0" %>
-                <% else %>
-                  <div class="flex items-center justify-center w-11 h-11 rounded-full text-base font-bold shrink-0 <%= avatar_class %>">
-                    <%= user.initials %>
-                  </div>
-                <% end %>
-                <div class="min-w-0">
-                  <p class="font-semibold text-gray-900 leading-tight truncate"><%= user.full_name %></p>
-                  <p class="text-xs text-gray-400 truncate mt-0.5"><%= user.email %></p>
-                  <% if user.phone.present? %>
-                    <p class="text-xs text-gray-400 truncate mt-0.5"><i class="ph ph-phone"></i> <%= user.phone %></p>
-                  <% end %>
-                </div>
-              </div>
-
-              <div class="flex items-center justify-end mt-auto pt-3 border-t border-gray-100">
-                <%= link_to user, class: "flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-800" do %>
-                  <i class="ph ph-arrow-right"></i> <%= t(".show") %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      </div>
-    </details>
+    <%= render "role_group", role: role, users: users %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,7 @@ en:
     index:
       title: Users
       new_user: New user
+      recent_logins: Recent logins
       show: Show
     show:
       edit: Edit this user

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -149,6 +149,7 @@ es:
     index:
       title: Usuarios
       new_user: Nuevo usuario
+      recent_logins: Últimos accesos
       show: Ver
     show:
       edit: Editar este usuario

--- a/db/migrate/20260409160810_add_trackable_to_users.rb
+++ b/db/migrate/20260409160810_add_trackable_to_users.rb
@@ -1,0 +1,9 @@
+class AddTrackableToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :sign_in_count, :integer, default: 0, null: false
+    add_column :users, :current_sign_in_at, :datetime
+    add_column :users, :last_sign_in_at, :datetime
+    add_column :users, :current_sign_in_ip, :string
+    add_column :users, :last_sign_in_ip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_25_130051) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_160810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -142,6 +142,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_130051) do
     t.bigint "church_id"
     t.string "city"
     t.datetime "created_at", null: false
+    t.datetime "current_sign_in_at"
+    t.string "current_sign_in_ip"
     t.date "date_of_birth"
     t.integer "dni"
     t.string "email", default: "", null: false
@@ -157,12 +159,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_25_130051) do
     t.bigint "invited_by_id"
     t.string "invited_by_type"
     t.string "last_name"
+    t.datetime "last_sign_in_at"
+    t.string "last_sign_in_ip"
     t.datetime "locked_at"
     t.string "phone"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.integer "role", default: 0, null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.date "start_day"
     t.string "unlock_token"
     t.datetime "updated_at", null: false

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -199,4 +199,57 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     post stop_impersonating_path
     assert_redirected_to root_path
   end
+
+  # ---------------------------------------------------------------------------
+  # Recent logins
+  # ---------------------------------------------------------------------------
+
+  test "super_admin sees recent logins section on index" do
+    users(:one).update!(last_sign_in_at: 1.hour.ago)
+    sign_in users(:super_admin)
+    get users_url
+    assert_select "h2", text: /ltimos accesos|Recent logins/
+  end
+
+  test "non-super-admin does not see recent logins section on index" do
+    users(:one).update!(last_sign_in_at: 1.hour.ago)
+    sign_in users(:admin_user)
+    get users_url
+    assert_select "h2", text: /ltimos accesos|Recent logins/, count: 0
+  end
+
+  test "regular user does not see recent logins section on index" do
+    users(:one).update!(last_sign_in_at: 1.hour.ago)
+    sign_in users(:one)
+    get users_url
+    assert_select "h2", text: /ltimos accesos|Recent logins/, count: 0
+  end
+
+  test "recent_logins section shows for super_admin after sign in" do
+    sign_in users(:super_admin)
+    get users_url
+    assert_match(/ltimos accesos|Recent logins/, response.body)
+  end
+
+  test "recent_logins are ordered by last_sign_in_at descending" do
+    users(:one).update!(last_sign_in_at: 3.hours.ago)
+    users(:two).update!(last_sign_in_at: 2.hours.ago)
+    sign_in users(:super_admin)
+    get users_url
+    pos_two = response.body.index(users(:two).email)
+    pos_one = response.body.index(users(:one).email)
+    assert pos_two < pos_one, "More recently signed-in user should appear first"
+  end
+
+  test "recent_logins shows timestamp for users who have signed in" do
+    sign_in users(:super_admin)
+    users(:one).update!(last_sign_in_at: 30.minutes.ago)
+    get users_url
+    assert_select "i.ph-clock"
+  end
+
+  test "recent_logins query returns at most 20 records" do
+    recent = User.where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(20)
+    assert recent.size <= 20
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -249,7 +249,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "recent_logins query returns at most 20 records" do
-    recent = User.where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(20)
-    assert recent.size <= 20
+    assert User.recent_logins.size <= 20
   end
 end


### PR DESCRIPTION
## Summary

- Enables Devise `:trackable` module on the `User` model and adds the required DB columns (`sign_in_count`, `current_sign_in_at`, `last_sign_in_at`, `current_sign_in_ip`, `last_sign_in_ip`) via migration
- Adds a collapsible \"Últimos accesos / Recent logins\" section at the top of the users index page, visible only to super admin users, showing the last 20 users who signed in ordered by most recent login
- Each card displays the user's name, email, avatar/initials, and a formatted sign-in timestamp (`dd/mm/yyyy hh:mm`)
- Added i18n keys (`recent_logins`) for both `es` and `en` locales

## Test plan

- [ ] Sign in as a super admin and visit `/users` — the \"Últimos accesos\" collapsible section should appear at the top with up to 20 user cards
- [ ] Sign in as a regular admin or non-admin user and visit `/users` — the recent logins section should not be visible
- [ ] Verify the cards are ordered with the most recent sign-in first
- [ ] Verify users who have never signed in do not appear in the section
- [ ] Run `bundle exec rails test test/controllers/users_controller_test.rb` — all 32 tests should pass
- [ ] Run `bundle exec rails db:migrate` on staging/production to apply the trackable columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)