### PR TITLE
Agregar videos tutoriales en documentación de guardias y servicios

### DIFF
--- a/docs/guards/index.html
+++ b/docs/guards/index.html
@@ -11,6 +11,7 @@
     /* Guard-specific badge colours */
     .badge-open   { background: #d1fae5; color: #065f46; }
     .badge-closed { background: #fee2e2; color: #991b1b; }
+    .video-player { width: 100%; border-radius: 0.5rem; }
   </style>
 </head>
 <body>
@@ -148,10 +149,11 @@
       <!-- Video -->
       <p class="section-title"><i class="ph ph-video"></i> Vídeo explicativo</p>
       <div class="video-section">
-        <div class="video-placeholder">
-          <i class="ph ph-play-circle"></i>
-          <p>Vídeo próximamente disponible</p>
-        </div>
+        <video class="video-player" controls>
+          <source src="https://ssn-docs.s3.sa-east-1.amazonaws.com/abrir_guardia.mp4" type="video/mp4">
+          Tu navegador no soporta reproducción de vídeo.
+          <a href="https://ssn-docs.s3.sa-east-1.amazonaws.com/abrir_guardia.mp4">Descargar vídeo</a>.
+        </video>
         <div class="video-info">
           <h4>Cómo gestionar una guardia</h4>
           <p>Aprende a crear una guardia, asignar sacerdote, vocal y guardianes,

--- a/docs/services/index.html
+++ b/docs/services/index.html
@@ -11,6 +11,7 @@
     /* Service-specific badge colours */
     .badge-pending   { background: #fef9c3; color: #854d0e; }
     .badge-completed { background: #d1fae5; color: #065f46; }
+    .video-player { width: 100%; border-radius: 0.5rem; }
   </style>
 </head>
 <body>
@@ -144,10 +145,11 @@
       <!-- Video -->
       <p class="section-title"><i class="ph ph-video"></i> Vídeo explicativo</p>
       <div class="video-section">
-        <div class="video-placeholder">
-          <i class="ph ph-play-circle"></i>
-          <p>Vídeo próximamente disponible</p>
-        </div>
+        <video class="video-player" controls>
+          <source src="https://ssn-docs.s3.sa-east-1.amazonaws.com/registracion_servicios.mp4" type="video/mp4">
+          Tu navegador no soporta reproducción de vídeo.
+          <a href="https://ssn-docs.s3.sa-east-1.amazonaws.com/registracion_servicios.mp4">Descargar vídeo</a>.
+        </video>
         <div class="video-info">
           <h4>Cómo registrar un servicio</h4>
           <p>Aprende a registrar una atención durante una guardia activa: introducir los datos del fiel,


### PR DESCRIPTION
## Summary
- Reemplaza el placeholder "Vídeo próximamente disponible" por un elemento `<video>` con controles nativos del navegador en `docs/guards/index.html` y `docs/services/index.html`
- Los videos se sirven desde S3 (`ssn-docs.s3.sa-east-1.amazonaws.com`) para evitar almacenar archivos grandes en el repositorio
- Incluye fallback con link de descarga para navegadores sin soporte de video nativo

## Test plan
- [ ] Abrir `docs/guards/index.html` y verificar que el video "Cómo gestionar una guardia" se reproduce correctamente
- [ ] Abrir `docs/services/index.html` y verificar que el video "Cómo registrar un servicio" se reproduce correctamente
- [ ] Verificar que los videos cargan desde las URLs de S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)